### PR TITLE
fix: allow fallback to non-coreml at runtime

### DIFF
--- a/Sources/whisper/include/whisper.h
+++ b/Sources/whisper/include/whisper.h
@@ -137,14 +137,14 @@ extern "C" {
         struct whisper_context * ctx,
                    const float * samples,
                            int   n_samples,
-                           int   n_threads);
+                               int   n_threads);
 
     WHISPER_API int whisper_pcm_to_mel_phase_vocoder_with_state(
         struct whisper_context * ctx,
           struct whisper_state * state,
                    const float * samples,
                            int   n_samples,
-                           int   n_threads);
+                               int   n_threads);
 
     // This can be used to set a custom log mel spectrogram inside the default state of the provided whisper context.
     // Use this instead of whisper_pcm_to_mel() if you want to provide your own log mel spectrogram.
@@ -170,13 +170,15 @@ extern "C" {
     WHISPER_API int whisper_encode(
             struct whisper_context * ctx,
                                int   offset,
-                               int   n_threads);
+                               int   n_threads,
+			       bool  use_coreml);
 
     WHISPER_API int whisper_encode_with_state(
             struct whisper_context * ctx,
               struct whisper_state * state,
                                int   offset,
-                               int   n_threads);
+                               int   n_threads,
+			       bool  use_coreml);
 
     // Run the Whisper decoder to obtain the logits and probabilities for the next token.
     // Make sure to call whisper_encode() first.
@@ -232,6 +234,7 @@ extern "C" {
             struct whisper_context * ctx,
                                int   offset_ms,
                                int   n_threads,
+			       bool  use_coreml,
                              float * lang_probs);
 
     WHISPER_API int whisper_lang_auto_detect_with_state(
@@ -239,6 +242,7 @@ extern "C" {
               struct whisper_state * state,
                                int   offset_ms,
                                int   n_threads,
+			       bool  use_coreml,
                              float * lang_probs);
 
     WHISPER_API int whisper_n_len           (struct whisper_context * ctx); // mel length
@@ -407,6 +411,7 @@ extern "C" {
         // called by each decoder to filter obtained logits
         whisper_logits_filter_callback logits_filter_callback;
         void * logits_filter_callback_user_data;
+	bool use_coreml;
     };
 
     WHISPER_API struct whisper_full_params whisper_full_default_params(enum whisper_sampling_strategy strategy);

--- a/Sources/whisper/include/whisper.h
+++ b/Sources/whisper/include/whisper.h
@@ -137,14 +137,14 @@ extern "C" {
         struct whisper_context * ctx,
                    const float * samples,
                            int   n_samples,
-                               int   n_threads);
+                           int   n_threads);
 
     WHISPER_API int whisper_pcm_to_mel_phase_vocoder_with_state(
         struct whisper_context * ctx,
           struct whisper_state * state,
                    const float * samples,
                            int   n_samples,
-                               int   n_threads);
+                           int   n_threads);
 
     // This can be used to set a custom log mel spectrogram inside the default state of the provided whisper context.
     // Use this instead of whisper_pcm_to_mel() if you want to provide your own log mel spectrogram.

--- a/Sources/whisper/whisper.cpp
+++ b/Sources/whisper/whisper.cpp
@@ -1453,7 +1453,7 @@ static bool whisper_encode_internal(
     }
 
     struct ggml_tensor * cur;
-    bool use_coreml_surely = use_coreml;
+    bool use_coreml_surely = wstate.ctx_coreml != nullptr;
 
     if (use_coreml_surely) {
         wstate.use_buf(ctx0, -1);

--- a/Sources/whisper/whisper.cpp
+++ b/Sources/whisper/whisper.cpp
@@ -1453,7 +1453,7 @@ static bool whisper_encode_internal(
     }
 
     struct ggml_tensor * cur;
-    bool use_coreml_surely = wstate.ctx_coreml != nullptr;
+    bool use_coreml_surely = use_coreml && wstate.ctx_coreml != nullptr;
 
     if (use_coreml_surely) {
         wstate.use_buf(ctx0, -1);

--- a/Sources/whisper/whisper.cpp
+++ b/Sources/whisper/whisper.cpp
@@ -1463,7 +1463,7 @@ static bool whisper_encode_internal(
         whisper_coreml_encode(wstate.ctx_coreml, (float *) mel->data, (float *) cur->data);
 	 for (int i = 0; i < cur -> ne[0]; ++i) {
 	    if (isnan(((float *)(cur->data))[i])) {
-		// TODO: Greeshma throw error
+    		fprintf(stderr, "CoreML data error. Falling back to non CoreML implementation");
 		use_coreml_surely = false;
 	    }
 	}


### PR DESCRIPTION
* Instead of compile time, use runtime option to enable coreML. This is currently passed through `whisper_full_parameters`.
* Fallback to non-coreML when we detect issues with coreML encoded data. 
* This will allow us to ship to Mac without the issues we saw in [MEM-3615](https://linear.app/rewindai/issue/MEM-3615/gracefully-handle-whispercpp-asserts#comment-4238ab08)
